### PR TITLE
Comment on unimplemented new()

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -13,7 +13,7 @@
 //! # Fx Hash
 //!
 //! This hashing algorithm was extracted from the Rustc compiler.  This is the same hashing
-//! algorithm used for some internal operations in FireFox.  The strength of this algorithm
+//! algorithm used for some internal operations in Firefox.  The strength of this algorithm
 //! is in hashing 8 bytes at a time on 64-bit platforms, where the FNV algorithm works on one
 //! byte at a time.
 //!
@@ -37,9 +37,15 @@ use byteorder::{ByteOrder, NativeEndian};
 pub type FxBuildHasher = BuildHasherDefault<FxHasher>;
 
 /// A `HashMap` using a default Fx hasher.
+///
+/// Use `FxHashMap::default()`, not `new()` to create a new `FxHashMap`.
+/// To create with a reserved capacity, use `FxHashMap::with_capacity_and_hasher(num, Default::default())`.
 pub type FxHashMap<K, V> = HashMap<K, V, FxBuildHasher>;
 
 /// A `HashSet` using a default Fx hasher.
+///
+/// Note: Use `FxHashSet::default()`, not `new()` to create a new `FxHashSet`.
+/// To create with a reserved capacity, use `FxHashSet::with_capacity_and_hasher(num, Default::default())`.
 pub type FxHashSet<V> = HashSet<V, FxBuildHasher>;
 
 const ROTATE: u32 = 5;


### PR DESCRIPTION
It's not obvious that `new()` and `with_capacity()` don't work. I've added a note about this to the docs.

Could you publish a new version? Github has updated readme, but crates.io still shows broken code: https://crates.io/crates/fxhash