### PR TITLE
Fix a few minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This hashing algorithm was extracted from the Rustc compiler.  This is the same 
 
 ## Disclaimer
 
-It is **not a cryptographically secure** hash, so it is strongly recommended that you do not use this hash for cryptographic purproses.  Furthermore, this hashing algorithm was not designed to prevent any attacks for determining collisions which could be used to potentially cause quadratic behavior in `HashMap`s.  So it is not recommended to expose this hash in places where collissions or DDOS attacks may be a concern.
+It is **not a cryptographically secure** hash, so it is strongly recommended that you do not use this hash for cryptographic purposes.  Furthermore, this hashing algorithm was not designed to prevent any attacks for determining collisions which could be used to potentially cause quadratic behavior in `HashMap`s.  So it is not recommended to expose this hash in places where collisions or DDOS attacks may be a concern.
 
 ## Examples
 


### PR DESCRIPTION
Fixes a few minor typos in the `README` (which were also showing up in
the Rust and Crate docs):

* purproses -> purposes
* collissions -> collisions

Additionally: I was reading the docs without much context on this
library on or hashing in Rust in general. The docs here mention the
"FNV" algorithm as an alternative to FxHash, but as a layman reader it
wasn't clear to me where FNV is used (in Rustc? as the `HashMap`
default?). If you want to give me a one liner with some context on that,
I'd be happy to flesh it out a bit and add it to the README.