### PR TITLE
Add const functions for hashing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ name = "fxhash"
 path = "bench.rs"
 
 [dependencies]
-byteorder = "1.0.0"
 
 [dev-dependencies]
 seahash = "3.0.5"

--- a/lib.rs
+++ b/lib.rs
@@ -404,6 +404,6 @@ pub const fn hash32_bytes(v: &[u8]) -> u32 {
 }
 
 /// A const function for when you need a 64-bit hash of a byte array.
-pub const fn hash64_bytes(v: &[u8]) -> u32 {
-    write32(0, v)
+pub const fn hash64_bytes(v: &[u8]) -> u64 {
+    write64(0, v)
 }

--- a/lib.rs
+++ b/lib.rs
@@ -29,9 +29,7 @@ use std::collections::{HashMap, HashSet};
 use std::default::Default;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::ops::BitXor;
-
-extern crate byteorder;
-use byteorder::{ByteOrder, NativeEndian};
+use std::convert::TryInto;
 
 /// A builder for default Fx hashers.
 pub type FxBuildHasher = BuildHasherDefault<FxHasher>;
@@ -79,12 +77,12 @@ impl_hash_word!(usize = SEED, u32 = SEED32, u64 = SEED64);
 #[inline]
 fn write32(mut hash: u32, mut bytes: &[u8]) -> u32 {
     while bytes.len() >= 4 {
-        hash.hash_word(NativeEndian::read_u32(bytes));
+        hash.hash_word(u32::from_ne_bytes(bytes[..4].try_into().unwrap()));
         bytes = &bytes[4..];
     }
 
     if bytes.len() >= 2 {
-        hash.hash_word(u32::from(NativeEndian::read_u16(bytes)));
+        hash.hash_word(u32::from(u16::from_ne_bytes(bytes[..2].try_into().unwrap())));
         bytes = &bytes[2..];
     }
 
@@ -98,17 +96,17 @@ fn write32(mut hash: u32, mut bytes: &[u8]) -> u32 {
 #[inline]
 fn write64(mut hash: u64, mut bytes: &[u8]) -> u64 {
     while bytes.len() >= 8 {
-        hash.hash_word(NativeEndian::read_u64(bytes));
+        hash.hash_word(u64::from_ne_bytes(bytes[..8].try_into().unwrap()));
         bytes = &bytes[8..];
     }
 
     if bytes.len() >= 4 {
-        hash.hash_word(u64::from(NativeEndian::read_u32(bytes)));
+        hash.hash_word(u64::from(u32::from_ne_bytes(bytes[..4].try_into().unwrap())));
         bytes = &bytes[4..];
     }
 
     if bytes.len() >= 2 {
-        hash.hash_word(u64::from(NativeEndian::read_u16(bytes)));
+        hash.hash_word(u64::from(u16::from_ne_bytes(bytes[..2].try_into().unwrap())));
         bytes = &bytes[2..];
     }
 

--- a/lib.rs
+++ b/lib.rs
@@ -397,3 +397,13 @@ pub fn hash<T: Hash + ?Sized>(v: &T) -> usize {
     v.hash(&mut state);
     state.finish() as usize
 }
+
+/// A const function for when you need a 32-bit hash of a byte array.
+pub const fn hash32_bytes(v: &[u8]) -> u32 {
+    write32(0, v)
+}
+
+/// A const function for when you need a 64-bit hash of a byte array.
+pub const fn hash64_bytes(v: &[u8]) -> u32 {
+    write32(0, v)
+}


### PR DESCRIPTION
This PR adds const functions for generating 32-bit and 64-bit hashes from byte slices.  This allows the generation of hashes at compile time.

Builds on #13