### PR TITLE
add throughput to benches

### DIFF
--- a/bench.rs
+++ b/bench.rs
@@ -26,6 +26,7 @@ macro_rules! generate_benches {
             #[bench]
             fn $fx(b: &mut Bencher) {
                 let s = black_box($s);
+                b.bytes = s.len();
                 b.iter(|| {
                     fxhash::hash(&s)
                 })
@@ -34,6 +35,7 @@ macro_rules! generate_benches {
             #[bench]
             fn $fx32(b: &mut Bencher) {
                 let s = black_box($s);
+                b.bytes = s.len();
                 b.iter(|| {
                     fxhash::hash32(&s)
                 })
@@ -42,6 +44,7 @@ macro_rules! generate_benches {
             #[bench]
             fn $fx64(b: &mut Bencher) {
                 let s = black_box($s);
+                b.bytes = s.len();
                 b.iter(|| {
                     fxhash::hash64(&s)
                 })
@@ -50,6 +53,7 @@ macro_rules! generate_benches {
             #[bench]
             fn $fnv(b: &mut Bencher) {
                 let s = black_box($s);
+                b.bytes = s.len();
                 b.iter(|| {
                     fnvhash(&s)
                 })
@@ -58,6 +62,7 @@ macro_rules! generate_benches {
             #[bench]
             fn $sea(b: &mut Bencher) {
                 let s = black_box($s);
+                b.bytes = s.len();
                 b.iter(|| {
                     seahash(&s)
                 })


### PR DESCRIPTION
Throughput often provides more precision when the benchmarks take a couple of nanoseconds

for example, there's a difference between these two hidden just by the ns/iter:
```
test bench_fx64_003    ... bench:           2 ns/iter (+/- 1) = 1500 MB/s
test bench_fx64_004    ... bench:           2 ns/iter (+/- 0) = 2000 MB/s
